### PR TITLE
chore: use nix3 hash conversion interface

### DIFF
--- a/lua/nixhash.lua
+++ b/lua/nixhash.lua
@@ -6,7 +6,7 @@ end
 
 -- converts the hash to base32
 local function toBase32(txt)
-  local base32 = vim.fn.system({"nix-hash", "--type", "sha256", "--to-base32", txt})
+  local base32 = vim.fn.system({"nix", "hash", "convert", "--hash-algo", "sha256", "--to", "nix32", txt})
   local words = vim.fn.split(base32)
   if #words > 1 then error("nix-hash failed: "..base32) end
   local res = words[#words]
@@ -16,7 +16,7 @@ end
 
 -- converts the hash to base16
 local function toBase16(txt)
-  local base16 = vim.fn.system({"nix-hash", "--type", "sha256", "--to-base16", txt})
+  local base16 = vim.fn.system({"nix", "hash", "convert", "--hash-algo", "sha256", "--to", "base16", txt})
   local words = vim.fn.split(base16)
   if #words > 1 then error("nix-hash failed: "..base16) end
   local res = words[#words]


### PR DESCRIPTION
on Nix 2.22.3, `nix-hash` outputs a deprecation warning. The last line in the output is still the converted hash, but this breaks the `vim.fn.split` parser.

```
warning: The old format conversion sub commands of `nix hash` where deprecated in favor of `nix hash convert`.
```

Unfortunately, Lix 2.90 does not provide `nix hash convert` so there is a compatibility issue. It may be better to keep the old command and split by line terminators instead.